### PR TITLE
@pnp/sp: Export classes from contenttypes and regionalsettings

### DIFF
--- a/packages/sp/src/sp.ts
+++ b/packages/sp/src/sp.ts
@@ -38,6 +38,14 @@ export {
 export * from "./clientsidepages";
 
 export {
+    ContentType,
+    ContentTypes,
+    ContentTypeAddResult,
+    FieldLink,
+    FieldLinks,
+} from "./contenttypes";
+
+export {
     SPConfiguration,
     SPConfigurationPart,
 } from "./config/splibconfig";
@@ -100,6 +108,13 @@ export {
     ListUpdateResult,
     ListEnsureResult,
 } from "./lists";
+
+export {
+    RegionalSettings,
+    InstalledLanguages,
+    TimeZone,
+    TimeZones,
+} from "./regionalsettings";
 
 export {
     RelatedItem,


### PR DESCRIPTION
#### Category
- [X] Bug fix?
- [X] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

No related issues.

#### What's in this Pull Request?

Currently eg. ContentType can be imported by directly referencing the file:
import { ContentType } from "@pnp/sp/src/contenttypes";

This PR will export ContentType from @pnp/sp like other classes.

