### PR TITLE
Readme fixes: slashes in packages names

### DIFF
--- a/packages/common/docs/index.md
+++ b/packages/common/docs/index.md
@@ -8,7 +8,7 @@ The common modules provides a set of utilities classes and reusable building blo
 
 Install the library and required dependencies
 
-`npm install @pnp\logging @pnp\common --save`
+`npm install @pnp/logging @pnp/common --save`
 
 Import and use functionality, see details on modules below.
 

--- a/packages/config-store/docs/index.md
+++ b/packages/config-store/docs/index.md
@@ -8,7 +8,7 @@ This module providers a way to load application configuration from one or more p
 
 Install the library and required dependencies
 
-`npm install @pnp\logging @pnp\common @pnp\odata @pnp\sp @pnp\config-store --save`
+`npm install @pnp/logging @pnp/common @pnp/odata @pnp/sp @pnp/config-store --save`
 
 See the topics below for usage:
 

--- a/packages/nodejs/docs/index.md
+++ b/packages/nodejs/docs/index.md
@@ -7,10 +7,10 @@ Primarily these consist of clients to enable use of the libraries in nodejs.
 
 ## Getting Started
 
-Install the library and required dependencies. You will also need to install other libraries such as [@pnp/sp](../sp) or [@pnp/graph](../graph) to use the 
+Install the library and required dependencies. You will also need to install other libraries such as [@pnp/sp](../sp) or [@pnp/graph](../graph) to use the
 exported functionality.
 
-`npm install @pnp\logging @pnp\common @pnp\nodejs --save`
+`npm install @pnp/logging @pnp/common @pnp/nodejs --save`
 
 * [AdalFetchClient](adal-fetch-client.md)
 * [SPFetchClient](sp-fetch-client.md)

--- a/packages/odata/docs/index.md
+++ b/packages/odata/docs/index.md
@@ -10,7 +10,7 @@ the core code is solid and well tested, with any updates benefitting all inherit
 
 Install the library and required dependencies
 
-`npm install @pnp\logging @pnp\common @pnp\odata --save`
+`npm install @pnp/logging @pnp/common @pnp/odata --save`
 
 ## Library Topics
 

--- a/packages/sp-addinhelpers/docs/index.md
+++ b/packages/sp-addinhelpers/docs/index.md
@@ -14,7 +14,7 @@ Now you can make requests to the host web from your add-in using the crossDomain
 
 ```TypeScript
 // note we are getting the sp variable from this library, it extends the sp export from @pnp/sp to add the required helper methods
-import { sp, SPRequestExecutorClient } from "@pnp\sp-addinhelpers";
+import { sp, SPRequestExecutorClient } from "@pnp/sp-addinhelpers";
 
 // this only needs to be done once within your application
 sp.setup({

--- a/packages/sp-addinhelpers/docs/sp-request-executor-client.md
+++ b/packages/sp-addinhelpers/docs/sp-request-executor-client.md
@@ -5,12 +5,12 @@ the SharePoint SP product libraries being present to allow use of the SP.Request
 
 ## Setup
 
-To use the client you need to set it using the fetch client factory using the setup  method as shown below. This is only required when working within a 
+To use the client you need to set it using the fetch client factory using the setup  method as shown below. This is only required when working within a
 SharePoint add-in web.
 
 ```TypeScript
 // note we are getting the sp variable from this library, it extends the sp export from @pnp/sp to add the required helper methods
-import { sp, SPRequestExecutorClient } from "@pnp\sp-addinhelpers";
+import { sp, SPRequestExecutorClient } from "@pnp/sp-addinhelpers";
 
 // this only needs to be done once within your application
 sp.setup({

--- a/packages/sp-addinhelpers/docs/sp-rest-addin.md
+++ b/packages/sp-addinhelpers/docs/sp-rest-addin.md
@@ -4,7 +4,7 @@ This class extends the sp export from @pnp/sp and adds in the methods required t
 
 ```TypeScript
 // note we are getting the sp variable from this library, it extends the sp export from @pnp/sp to add the required helper methods
-import { sp, SPRequestExecutorClient } from "@pnp\sp-addinhelpers";
+import { sp, SPRequestExecutorClient } from "@pnp/sp-addinhelpers";
 
 // this only needs to be done once within your application
 sp.setup({


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [x] Documentation update?

#### Related Issues

mentioned in #25

#### What's in this Pull Request?

In some places, there are the wrong package names because of the reverse slash. I.e. `@pnp\sp` but not `@pnp/sp` which causes some controversy while "blind copying".
