### PR TITLE
Add support for $expand in getAll (items.expand('...'))

### DIFF
--- a/packages/sp/src/items.ts
+++ b/packages/sp/src/items.ts
@@ -91,7 +91,7 @@ export class Items extends SharePointQueryableCollection {
         // $select - allow picking the return fields (good behavior)
         // $filter - allow setting a filter, though this may fail due for large lists
         this.query.getKeys()
-            .filter(k => /^\$select$|^\$filter$|^\$top$/.test(k.toLowerCase()))
+            .filter(k => /^\$select$|^\$filter$|^\$top$|^\$expand$/.test(k.toLowerCase()))
             .reduce((i, k) => {
                 i.query.add(k, this.query.get(k));
                 return i;


### PR DESCRIPTION
This fix adds support for expand by adding it to list of keys
copied from `this.query`.

#### Category
- [ ] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?
- [x] Feature enhancement?

#### What's in this Pull Request?

This PR add support for expand to the new `getAll` method.
We discussed this on gitter, and I understand that expand was deliberately excluded from `getAll` because of performance reasons.
While I understand the decision I still would like the ability to get all data in the exact same was as with `items.get()`.

The reason I want this is that we often use pnp for small snippets (using [tick](https://www.npmjs.com/package/tick-cli)), and then we need to run expand to do one-time jobs where we need more data, even if they are slow.