### PR TITLE
creating a queryable base class distinct from odataqueryable

### DIFF
--- a/packages/graph/src/graphqueryable.ts
+++ b/packages/graph/src/graphqueryable.ts
@@ -38,11 +38,7 @@ export class GraphQueryable<GetType = any> extends ODataQueryable<GraphBatch, Ge
             this._parentUrl = urlStr;
             this._url = Util.combinePaths(urlStr, path);
         } else {
-
-            const q = baseUrl as GraphQueryable;
-            this._parentUrl = q._url;
-            this._options = q._options;
-            this._url = Util.combinePaths(this._parentUrl, path);
+            this.extend(baseUrl as GraphQueryable, path);
         }
     }
 

--- a/packages/sp/src/sharepointqueryable.ts
+++ b/packages/sp/src/sharepointqueryable.ts
@@ -56,13 +56,11 @@ export class SharePointQueryable<GetType = any> extends ODataQueryable<SPBatch, 
             }
         } else {
             const q = baseUrl as SharePointQueryable;
-            this._parentUrl = q._url;
-            this._options = q._options;
+            this.extend(q, path);
             const target = q._query.get("@target");
             if (target !== null) {
                 this._query.add("@target", target);
             }
-            this._url = Util.combinePaths(this._parentUrl, path);
         }
     }
 


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [X] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

none

#### What's in this Pull Request?

Creates a distinct queryable base class that is more generic that odataqueryable and forms the base for all queryable classes throughout the libraries.